### PR TITLE
Fixing only_files_starts_with handling.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,10 +20,12 @@ async function run() {
             files = files.filter(currentFile => currentFile.toLowerCase().endsWith(`.${fileExtension}`))
 
         if (onlyStartsWith) {
+            let onlyStartsFiles = new Array();
             const onlyList = onlyStartsWith.split(onlyStartsWithDelimiter)
             onlyList.forEach(currentOnlyStartsWith => {
-                files = files.filter(currentFile => currentFile.startsWith(currentOnlyStartsWith))
+                onlyStartsFiles = onlyStartsFiles.concat(files.filter(currentFile => currentFile.startsWith(currentOnlyStartsWith)))
             });
+            files = onlyStartsFiles
         }
 
         if (ignoreStartsWith) {

--- a/index.test.js
+++ b/index.test.js
@@ -139,3 +139,23 @@ test('test only files which starts with *second*', () => {
   expect(result).not.toContain(fileName4)
 })
 
+test('test only files which starts with *first* or *second*', () => {
+   process.env['INPUT_DIRECTORY'] = testDir;
+   process.env['INPUT_ONLY_FILES_STARTS_WITH'] = "first;second";
+   process.env['INPUT_ONLY_FILES_STARTS_WITH_DELIMITER'] = ";";
+ 
+   const result = cp.execSync(`node ${ip}`, { env: process.env }).toString();
+ 
+   expect(result).toContain(outputFiles)
+   expect(result).toContain(outputFileNames)
+ 
+   expect(result).toContain(file1)
+   expect(result).toContain(file2)
+   expect(result).not.toContain(file3)
+   expect(result).not.toContain(file4)
+ 
+   expect(result).toContain(fileName1)
+   expect(result).toContain(fileName2)
+   expect(result).not.toContain(fileName3)
+   expect(result).not.toContain(fileName4)
+ })


### PR DESCRIPTION
I noticed that only_files_starts_with does not work with multiple values specified. This pull request resolves this issue.